### PR TITLE
remove constants

### DIFF
--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -1,1 +1,0 @@
-const splashBackgroundImage = './assets/images/splash_bg.jpg';

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'constants/constants.dart';
 import 'main_screen.dart';
 
 class SplashPage extends StatefulWidget {
@@ -43,7 +42,7 @@ class SplashState extends State<SplashPage> with TickerProviderStateMixin {
     return FadeTransition(
       opacity: animation,
       child: Image.asset(
-        splashBackgroundImage,
+        'assets/images/splash_bg.jpg',
         fit: BoxFit.fill,
       ),
     );


### PR DESCRIPTION
constants 的坏处：
- 多了一个名称，导致理解多一层间接
- 多了一个依赖
- constants 貌似可以装载一切变量，如果大家都依赖 constants，迟早会变成一个大杂烩



解决方案：
- 按使用处内聚程度，约定变量放置位置
- 如果多个模块都依赖一个`变量`，采用参数等方式解耦合
